### PR TITLE
Fix usart init error which will cause assert failure

### DIFF
--- a/software/platform/drivers/usart.c
+++ b/software/platform/drivers/usart.c
@@ -331,6 +331,7 @@ static void NVIC_Configuration(struct stm32_uart* uart)
 
 	/* Enable the USART1 Interrupt */
 	NVIC_InitStructure.NVIC_IRQChannel = uart->irq;
+	NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 0;
 	NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
 	NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
 	NVIC_Init(&NVIC_InitStructure);


### PR DESCRIPTION
Uninitialized struct member may cause assert failure in `NVIC_Init()`

```
assert_param(IS_NVIC_PREEMPTION_PRIORITY(NVIC_InitStruct->NVIC_IRQChannelPreemptionPriority));  
```
