### PR TITLE
Add tone() for 50% square waveform

### DIFF
--- a/software/cores/arduino/Arduino.h
+++ b/software/cores/arduino/Arduino.h
@@ -101,6 +101,7 @@ int digitalRead(uint8_t);
 int analogRead(uint8_t);
 void analogReference(uint8_t mode);
 void analogWrite(uint8_t, int);
+void tone(uint8_t, uint16_t, unsigned long);
 
 unsigned long millis(void);
 unsigned long micros(void);
@@ -200,7 +201,6 @@ uint16_t makeWord(byte h, byte l);
 
 unsigned long pulseIn(uint8_t pin, uint8_t state, unsigned long timeout = 1000000L);
 
-void tone(uint8_t _pin, unsigned int frequency, unsigned long duration = 0);
 void noTone(uint8_t _pin);
 
 // WMath prototypes

--- a/software/cores/arduino/Tone.cpp
+++ b/software/cores/arduino/Tone.cpp
@@ -227,7 +227,7 @@ static int8_t toneBegin(uint8_t _pin)
 
 
 // frequency (in hertz) and duration (in milliseconds).
-
+#if 0 // moved to libarduino
 void tone(uint8_t _pin, unsigned int frequency, unsigned long duration)
 {
   uint8_t prescalarbits = 0b001;
@@ -406,7 +406,7 @@ void tone(uint8_t _pin, unsigned int frequency, unsigned long duration)
     }
   }
 }
-
+#endif
 
 // XXX: this function only works properly for timer 2 (the only one we use
 // currently).  for the others, it should end the tone, but won't restore

--- a/software/platform/libarduino/libarduino.c
+++ b/software/platform/libarduino/libarduino.c
@@ -287,6 +287,17 @@ void analogWrite(uint8_t pin, uint8_t value)
 }
 FINSH_FUNCTION_EXPORT(analogWrite, write analog value to digital pin using pwm);
 
+/* normally the tone frequency should be 31 to 4978, refer to piches.h */
+void tone(uint8_t pin, uint16_t frequency, unsigned long duration)
+{
+	RT_ASSERT(frequency * 2 < UINT16_MAX);
+	pwmConfig(pin, UINT8_MAX / 2, frequency, UINT16_MAX);
+	rt_thread_delay(rt_tick_from_millisecond(duration));
+	pinMode(pin, OUTPUT);
+	digitalWrite(pin, LOW);
+}
+FINSH_FUNCTION_EXPORT(tone, generates a square wave of specified freqency (and 50% duty cycle) on a pin);
+
 volatile static voidFuncPtr intFunc[EXTERNAL_NUM_INTERRUPTS];
 
 static void defaultIsrHandler(void)
@@ -322,6 +333,7 @@ RTM_EXPORT(pinMode);
 RTM_EXPORT(digitalWrite);
 RTM_EXPORT(digitalRead);
 RTM_EXPORT(analogWrite);
+RTM_EXPORT(tone);
 
 RTM_EXPORT(attachInterrupt);
 RTM_EXPORT(detachInterrupt);


### PR DESCRIPTION
Reusing `pwmConfig()` and `rt_thread_delay()` for implementation of `tone()`.

It is not the best efficient way but the most simple one.
