### PR TITLE
Add rt-thread as submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ ide/app/pde.jar
 ide/core/core.jar
 software/platform/build
 software/platform/project*
-software/rt-thread
 
 /software/cores/rtconfig.py
 /software/examples/rtconfig.py

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "software/rt-thread"]
 	path = software/rt-thread
-	url = git@github.com:RT-Thread/rt-thread.git
+	url = https://github.com/RT-Thread/rt-thread.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "software/rt-thread"]
+	path = software/rt-thread
+	url = git@github.com:RT-Thread/rt-thread.git

--- a/software/rt-thread/README
+++ b/software/rt-thread/README
@@ -1,7 +1,0 @@
-Please put RT-Thread offical release under this folder.
-
-Use this command to check out the latest project source code from google code:
-    svn checkout http://rt-thread.googlecode.com/svn/trunk rt-thread
-    
-or download RT-Thread source code from:
-https://code.google.com/p/rt-thread/downloads/list


### PR DESCRIPTION
It is now possible to use `git submodule update` to retrieve the rt-thread source for ART
